### PR TITLE
Make compatible with apple

### DIFF
--- a/generator.c
+++ b/generator.c
@@ -36,13 +36,13 @@ void generator_init(void)
 // Linux x86_64 call convention
 // %rdi, %rsi, %rdx, %rcx, %r8, and %r9
 
-void* __attribute__((naked)) generator_next(Generator *g, void *arg)
+void* __attribute__((naked)) generator_next(__attribute__((unused)) Generator *g, __attribute__((unused)) void *arg)
 {
-    UNUSED(g);
-    UNUSED(arg);
     // @arch
-    if(g->dead){asm("xor %rax, %rax\n ret\n");}
     asm(
+    "    movb  16(%rdi), %al\n"         // %al = g->dead  (0 or 1)
+    "    decb  %al\n"                   // %al = %al - 1
+    "    jz    return_with_zero\n"      // if (!c) goto return_with_zero
     "    pushq %rdi\n"
     "    pushq %rbp\n"
     "    pushq %rbx\n"
@@ -51,13 +51,15 @@ void* __attribute__((naked)) generator_next(Generator *g, void *arg)
     "    pushq %r14\n"
     "    pushq %r15\n"
     "    movq %rsp, %rdx\n"     // rsp
-    "    jmp generator_switch_context\n");
+    "    jmp generator_switch_context\n"
+    "    return_with_zero:\n"
+    "       ret\n"
+    );
 }
 
-void __attribute__((naked)) generator_restore_context(void *rsp)
+void __attribute__((naked)) generator_restore_context(__attribute__((unused)) void *rsp)
 {
     // @arch
-    (void)rsp;
     asm(
     "    movq %rdi, %rsp\n"
     "    popq %r15\n"
@@ -70,11 +72,9 @@ void __attribute__((naked)) generator_restore_context(void *rsp)
     "    ret\n");
 }
 
-void __attribute__((naked)) generator_restore_context_with_return(void *rsp, void *arg)
+void __attribute__((naked)) generator_restore_context_with_return(__attribute__((unused)) void *rsp, __attribute__((unused)) void *arg)
 {
     // @arch
-    UNUSED(rsp);
-    UNUSED(arg);
     asm(
     "    movq %rdi, %rsp\n"
     "    movq %rsi, %rax\n"
@@ -105,9 +105,8 @@ void generator_switch_context(Generator *g, void *arg, void *rsp)
     }
 }
 
-void *__attribute__((naked)) generator_yield(void *arg)
+void *__attribute__((naked)) generator_yield(__attribute__((unused)) void *arg)
 {
-    UNUSED(arg);
     // @arch
     asm(
     "    pushq %rdi\n"


### PR DESCRIPTION
I've made two separate commits which can be cherry-picked.

# Remove non-ASM statement in naked function

Non-ASM statements in naked functions are undefined behaviour, only basic ASM statements can safely be included in naked functions. Clang won't even compile `(void)rsp;` statements, so I replaced them with `__attribite__((unused))`.

https://stackoverflow.com/a/47343399


# Add missing names for Apple and clang

Apple OSes doesn't have MAP_STACK or MAP_GROWSDOWN, so I replaced them with 0. They seem to be missing the `threads.h` header and `asm` keyword, so made simple defines for them that works for both gcc and clang.

Also, clang (and probably other compilers) prepend underscore to their labels.